### PR TITLE
Add verbose option to Vosk recognizer

### DIFF
--- a/reference/library-reference.rst
+++ b/reference/library-reference.rst
@@ -280,7 +280,7 @@ Returns the most likely transcription if ``show_all`` is false (the default). Ot
 
 Raises a ``speech_recognition.UnknownValueError`` exception if the speech is unintelligible. Raises a ``speech_recognition.RequestError`` exception if the speech recognition operation failed, if the key isn't valid, or if there is no internet connection.
 
-``recognizer_instance.recognize_vosk(audio_data: AudioData)``
+``recognizer_instance.recognize_vosk(audio_data: AudioData, *, verbose: bool = False)``
 --------------------------------------------------------------
 
 .. autofunction:: speech_recognition.recognizers.vosk.recognize

--- a/speech_recognition/recognizers/vosk.py
+++ b/speech_recognition/recognizers/vosk.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from typing import TYPE_CHECKING
 
@@ -7,11 +8,14 @@ if TYPE_CHECKING:
     from speech_recognition.audio import AudioData
 
 
-def recognize(recognizer, audio_data: AudioData) -> str:
+def recognize(recognizer, audio_data: AudioData, *, verbose: bool = False):
     """
     Perform speech recognition on ``audio_data`` using Vosk.
 
     Requires the Vosk model to be downloaded and unpacked in a folder named 'model' (``$PWD/model``).
+
+    If ``verbose`` is ``False`` (default), only the recognized text is returned.
+    If ``verbose`` is ``True``, the parsed result dictionary from Vosk is returned.
     """
 
     from vosk import KaldiRecognizer, Model
@@ -25,6 +29,10 @@ def recognize(recognizer, audio_data: AudioData) -> str:
     rec.AcceptWaveform(
         audio_data.get_raw_data(convert_rate=SAMPLE_RATE, convert_width=2)
     )
-    finalRecognition = rec.FinalResult()
+    final_recognition = rec.FinalResult()
 
-    return finalRecognition
+    result = json.loads(final_recognition)
+    if verbose:
+        return result
+
+    return result.get("text", "")

--- a/tests/recognizers/test_vosk.py
+++ b/tests/recognizers/test_vosk.py
@@ -10,9 +10,16 @@ def test_recognize_vosk():
 
     actual = sut.recognize_vosk(audio_data)
 
-    expected = """\
-{
-  "text" : "one two three"
-}\
-"""
+    expected = "one two three"
+    assert actual == expected
+
+
+def test_recognize_vosk_verbose():
+    audio_file = str(Path(__file__).parent.parent / "english.wav")
+    audio_data = AudioData.from_file(audio_file)
+    sut = Recognizer()
+
+    actual = sut.recognize_vosk(audio_data, verbose=True)
+
+    expected = {"text": "one two three"}
     assert actual == expected


### PR DESCRIPTION
## Summary
- update `vosk.recognize` to optionally return parsed dict
- adjust Vosk tests for default and verbose outputs
- document new parameter in the library reference

## Testing
- `python -m pip install -e .[dev,vosk]` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `python -m pytest tests/recognizers/test_vosk.py` *(fails: No module named pytest)*