### PR TITLE
Exclude `speech_recognition.models` from setuptools package discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ class InstallWithExtraSteps(install):
 setup(
     name="SpeechRecognition",
     version=speech_recognition.__version__,
-    packages=find_packages(exclude=["tests.*", "test"]),
+    packages=find_packages(exclude=["tests.*", "test", "speech_recognition.models"]),
     include_package_data=True,
     cmdclass={"install": InstallWithExtraSteps},
 


### PR DESCRIPTION
### Motivation
- Suppress setuptools warnings emitted during `make distribute` when a data-only directory (`speech_recognition/models`) is recognized as an importable package but is not included in the `packages` configuration.

### Description
- Updated `setup.py` to add `"speech_recognition.models"` to the `exclude` list passed to `find_packages(...)`, making the exclusion explicit (`packages=find_packages(exclude=["tests.*", "test", "speech_recognition.models"])`).

### Testing
- Ran `make distribute` which completed successfully and `twine check` passed for the generated artifacts, and the previous setuptools warning about `speech_recognition.models` no longer appears.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf620c128832c802d93692d691c2a)